### PR TITLE
CNP-1155-Java-chart-version - prevent pod from running container process as root

### DIFF
--- a/charts/am-api/requirements.yaml
+++ b/charts/am-api/requirements.yaml
@@ -3,6 +3,6 @@ dependencies:
   version: ~3.9.1
   repository: '@stable'
 - name: java
-  version: >=0.0.10
+  version: 0.0.12
   repository: '@hmcts'
   alias: am-api

--- a/charts/am-api/requirements.yaml
+++ b/charts/am-api/requirements.yaml
@@ -3,6 +3,6 @@ dependencies:
   version: ~3.9.1
   repository: '@stable'
 - name: java
-  version: 0.0.12
+  version: ~0.0.12
   repository: '@hmcts'
   alias: am-api

--- a/charts/am-api/requirements.yaml
+++ b/charts/am-api/requirements.yaml
@@ -3,6 +3,6 @@ dependencies:
   version: ~3.9.1
   repository: '@stable'
 - name: java
-  version: 0.0.9
+  version: >=0.0.10
   repository: '@hmcts'
   alias: am-api


### PR DESCRIPTION
This change will prevent pod from running container processes as root, please refer to the documentation for more details:
https://tools.hmcts.net/confluence/display/CNP/Pod+Security#PodSecurity-SecurityContext

IMPORTANT: Please ensure to update java helm chart version as we might be deleting/deprecating older helm charts from Azure Container Registry which will make the AKS preview deployments fail